### PR TITLE
feat: add style to agency page

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,4 +9,58 @@ body {
   padding: 0;
 }
 
+header {
+  border-bottom: 8px solid hsl(0deg, 0%, 60%);
+}
+
+.max-width-wrapper {
+  width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.intro-chunk {
+  padding: 96px 24px 64px 24px;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 48px;
+}
+
+.intro-chunk p {
+  font-size: 1.25rem;
+  max-width: 400px;
+}
+
+.intro-chunk p strong {
+  color: hsl(160deg, 100%, 30%);
+}
+
+main {
+  background-color: hsl(0deg, 0%, 40%);
+  padding-top: 72px;
+  height: 60%;
+}
+
+.card {
+  background-color: hsl(0deg, 0%, 100%);
+  padding: 8px 24px 24px 24px;
+  border-bottom: 8px solid hsl(0deg, 0%, 60%);
+}
+
+.indented-heading {
+  padding: 16px 24px;
+  background-color: hsl(45deg, 100%, 50%);
+  border-bottom: 8px solid hsl(45deg, 100%, 40%);
+  width: fit-content;
+  margin-top: 0px;
+  margin-left: -32px;
+  font-size: 1.5rem;
+}
+
+.card p {
+  font-size: 1.25rem;
+}
+
 /* Add styles here! */


### PR DESCRIPTION
Add the CSS styling to the Agency Page as per the [FIgma design](https://www.figma.com/file/6hGqKA5scrZJScb9KW3Hj2/Huckleberry).

Note the:
- auto margins for the `"max-width-wrapper"` div, and
- the negative margin to make the card header pop out.

![CleanShot 2024-01-01 at 15 47 36@2x](https://github.com/VrsajkovIvan33/huckleberry/assets/20580410/342d7e68-07ce-474d-876a-2588b9fd8a0f)
