### PR TITLE
fix: do workshop agency page corrections

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,12 +29,19 @@ header {
 .title {
   font-size: 2rem;
   line-height: 1.2;
-  margin-bottom: 48px;
+  margin: 0px;
+  margin-bottom: 3rem;
 }
 
-.p {
+p {
   font-size: 1.25rem;
   line-height: 1.5;
+  margin: 0px;
+  margin-bottom: 1rem;
+}
+
+p:last-child {
+  margin-bottom: 0px;
 }
 
 .intro-chunk p strong {
@@ -59,8 +66,10 @@ main {
   background-color: hsl(45deg, 100%, 50%);
   border-bottom: 8px solid hsl(45deg, 100%, 40%);
   width: fit-content;
+  margin: 0px;
   margin-top: -16px;
   margin-left: -32px;
+  margin-bottom: 1rem;
   font-size: 1.5rem;
   line-height: 1.2;
 }

--- a/style.css
+++ b/style.css
@@ -50,8 +50,7 @@ p:last-child {
 
 main {
   background-color: hsl(0deg, 0%, 40%);
-  padding-top: 72px;
-  height: 60%;
+  padding: 64px 0px;
 }
 
 .card {

--- a/style.css
+++ b/style.css
@@ -17,10 +17,12 @@ header {
   max-width: 800px;
   margin-left: auto;
   margin-right: auto;
+  padding: 0px 24px;
 }
 
 .intro-chunk {
-  padding: 96px 24px 64px 24px;
+  padding-top: 96px;
+  padding-bottom: 64px;
 }
 
 .title {
@@ -45,7 +47,8 @@ main {
 
 .card {
   background-color: hsl(0deg, 0%, 100%);
-  padding: 8px 24px 24px 24px;
+  padding: 24px;
+  margin: 0px -24px;
   border-bottom: 8px solid hsl(0deg, 0%, 60%);
 }
 
@@ -54,7 +57,7 @@ main {
   background-color: hsl(45deg, 100%, 50%);
   border-bottom: 8px solid hsl(45deg, 100%, 40%);
   width: fit-content;
-  margin-top: 0px;
+  margin-top: -16px;
   margin-left: -32px;
   font-size: 1.5rem;
 }

--- a/style.css
+++ b/style.css
@@ -23,16 +23,18 @@ header {
 .intro-chunk {
   padding-top: 96px;
   padding-bottom: 64px;
+  max-width: 415px;
 }
 
 .title {
   font-size: 2rem;
+  line-height: 1.2;
   margin-bottom: 48px;
 }
 
-.intro-chunk p {
+.p {
   font-size: 1.25rem;
-  max-width: 415px;
+  line-height: 1.5;
 }
 
 .intro-chunk p strong {
@@ -60,10 +62,7 @@ main {
   margin-top: -16px;
   margin-left: -32px;
   font-size: 1.5rem;
-}
-
-.card p {
-  font-size: 1.25rem;
+  line-height: 1.2;
 }
 
 /* Add styles here! */

--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ header {
 
 .intro-chunk p {
   font-size: 1.25rem;
-  max-width: 400px;
+  max-width: 415px;
 }
 
 .intro-chunk p strong {

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ header {
 }
 
 .max-width-wrapper {
-  width: 800px;
+  max-width: 800px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/style.css
+++ b/style.css
@@ -72,5 +72,3 @@ main {
   font-size: 1.5rem;
   line-height: 1.2;
 }
-
-/* Add styles here! */


### PR DESCRIPTION
Corrections after watching the solution video.

Most notably:
- Always set `line-height`.
- Remove default margins on text and set it manually.
- Move the common `24px` padding to the `max-width-wrapper`. Add negative margin on card to compensate.

![CleanShot 2024-01-01 at 17 17 13](https://github.com/VrsajkovIvan33/huckleberry/assets/20580410/2647e7c8-91bf-4bb8-90ea-3aa79fd5cbb2)
